### PR TITLE
feat: transition from MCP server to Skill-based integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ notifyme run --config myconfig -- ping -c 5 google.com
 notifyme run -- ping -c 5 google.com
 ```
 
+4. Send a notification directly (for integration):
+```bash
+notifyme send "Critical issue: Database is down!"
+```
+
+## Skill Integration (for Agents)
+
+NotifyMe can be used as a "Skill" for AI Agents (like Gemini CLI, Cursor, or specialized GPTs) to allow them to grab your attention when they hit a roadblock.
+
+### Installing for Gemini CLI
+
+Add the following to your Gemini CLI configuration or skill directory:
+
+1. Copy the `SKILL.md` file to your skills folder.
+2. Ensure the `notifyme` binary is in your `PATH`.
+3. The Agent will now be able to use the `notifyme send` command whenever it needs to notify you about critical events or manual intervention.
+
+### Integration Principle
+
+The `notifyme send` command is designed to be a "fire-and-forget" high-priority alert. When an Agent executes this command:
+- It uses your pre-configured channels (Lark, Telegram, etc.).
+- It automatically handles user mentions (@) and notification priority.
+- It provides a standardized `[NotifyMe]` prefix for easy filtering.
+
 ## Configuration
 
 Configurations are stored in XML format at `~/.config/notifyme/configs/`. Each configuration set can include multiple notification methods.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,38 @@
+# NotifyMe Skill
+
+This skill allows agents to send "high impact" notifications to the user using the `notify-me` CLI tool.
+It is designed for critical alerts where the agent needs to grab the user's attention (e.g., blocking issues, manual intervention required).
+
+## Installation
+
+Ensure `notifyme` is installed and available in your PATH, or reference the binary path directly.
+
+## Tools
+
+### `notify_send`
+
+Sends a high-priority notification via configured channels (Telegram, Lark, etc.).
+The notification will attempt to mention the user and use loud settings where applicable.
+
+**Command Structure:**
+`notifyme send <headline> [--config-set <config_set>]`
+
+**Description:**
+Sends a notification. This is always treated as a high-impact event requiring user attention.
+
+**Parameters:**
+
+- `headline` (string, required): The short summary of the event (max 100 chars recommended).
+- `config_set` (string, optional, default "default"): The configuration set to use (e.g., "default", "work", "personal").
+
+**Usage Examples:**
+
+1.  **Critical issue (Intervention needed)**:
+    ```bash
+    notifyme send "Database migration failed. Manual rollback required."
+    ```
+
+2.  **Blocking progress**:
+    ```bash
+    notifyme send "Cannot proceed without API key. Please check configuration."
+    ```

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
-use crate::config::{ConfigManager, ConfigSet, NotificationConfigs};
+use crate::config::{ConfigManager, ConfigSet};
 use crate::editor::Editor;
 use crate::executor::CommandExecutor;
+use crate::notifications::NotificationOptions;
 use log::{error, info};
 use std::error::Error;
 
@@ -111,6 +112,57 @@ impl App {
         println!("Config set '{}' updated.", name);
         Ok(())
     }
+
+    pub async fn send_notification(
+        &self,
+        config_set_name: &str,
+        headline: &str,
+    ) -> Result<(), Box<dyn Error>> {
+        info!("Sending notification with config set: {}", config_set_name);
+
+        // 1. Read the config set
+        let config_set = match self.config_manager.read_config(config_set_name) {
+            Ok(config) => config,
+            Err(e) => {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("Failed to read config set '{}': {}", config_set_name, e),
+                )))
+            }
+        };
+
+        // 2. Get notification handlers
+        let handlers = match config_set.get_notification_handlers() {
+            Ok(h) => h,
+            Err(e) => {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to get notification handlers: {}", e),
+                )))
+            }
+        };
+
+        // 3. Prepare message and options
+        // High impact default: Not silent, Mention user
+        let silent = false;
+        let mention_user = true;
+
+        let message = format!("[NotifyMe] {}", headline);
+        let options = NotificationOptions {
+            silent,
+            mention_user,
+        };
+
+        // 4. Send notifications
+        for handler in handlers {
+            if let Err(e) = handler.send_with_options(&message, &options).await {
+                error!("Failed to send notification: {}", e);
+            }
+        }
+
+        info!("Notification sent successfully");
+        Ok(())
+    }
 }
 
 // Keep these for backward compatibility
@@ -136,4 +188,13 @@ pub async fn run_command(
     args: &[String],
 ) -> Result<(), Box<dyn Error>> {
     App::new().run_command(config_set_name, cmd, args).await
+}
+
+pub async fn send_notification(
+    config_set_name: &str,
+    headline: &str,
+) -> Result<(), Box<dyn Error>> {
+    App::new()
+        .send_notification(config_set_name, headline)
+        .await
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -46,4 +46,14 @@ pub enum Commands {
         /// Configuration set name
         name: String,
     },
+    /// Send a notification directly (High Impact)
+    Send {
+        /// The notification headline/message
+        #[arg()]
+        headline: String,
+
+        /// Configuration set name
+        #[arg(short, long, default_value = "default")]
+        config_set: String,
+    },
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,16 +1,12 @@
 use crate::notifications::NotificationSender;
-use log::{error, info};
+use log::error;
 use quick_xml::de::from_str;
 use quick_xml::se::to_string;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::fs;
-use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
-use std::{collections::HashMap, io::Error};
 
 const CONFIG_DIR: &str = ".config/notifyme/configs/";
-const DEFAULT_CONFIG_NAME: &str = "default";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename = "config-set")]
@@ -47,6 +43,8 @@ pub enum NotificationConfigType {
 pub struct TelegramConfig {
     pub token: String,
     pub chat_id: String,
+    #[serde(default)]
+    pub at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -161,126 +159,6 @@ impl ConfigSet {
             handlers.push(handler);
         }
         Ok(handlers)
-    }
-
-    // unused temporarily, will be used for config write in the future
-    pub fn add_notification_config(&mut self, config_type: &str, params: HashMap<String, String>) {
-        // let value_params: HashMap<String, Value> = params
-        //     .into_iter()
-        //     .map(|(k, v)| (k, Value::String(v)))
-        //     .collect();
-
-        // self.notification_configs.configs.push(NotificationConfig {
-        //     config_type: config_type.to_string(),
-        //     config: match config_type.as_str() {
-        //         "telegram" => NotificationConfigType::Telegram(TelegramConfig {
-        //             token: params.get("token").unwrap().clone(),
-        //             chat_id: params.get("chat_id").unwrap().clone(),
-        //             message: params.get("message").map(|v| v.clone()),
-        //             parse_mode: params.get("parse_mode").map(|v| v.clone()),
-        //             disable_web_page_preview: params
-        //                 .get("disable_web_page_preview")
-        //                 .map(|v| v.parse::<bool>().unwrap()),
-        //             disable_notification: params
-        //                 .get("disable_notification")
-        //                 .map(|v| v.parse::<bool>().unwrap()),
-        //         }),
-        //         "email" => NotificationConfigType::Email(EmailConfig {
-        //             to: params.get("to").unwrap().clone(),
-        //             from: params.get("from").unwrap().clone(),
-        //             subject: params.get("subject").map(|v| v.clone()),
-        //             body: params.get("body").map(|v| v.clone()),
-        //             smtp: SmtpConfig {
-        //                 host: params.get("smtp_host").unwrap().clone(),
-        //                 port: params.get("smtp_port").unwrap().parse::<u16>().unwrap(),
-        //                 username: params.get("smtp_username").unwrap().clone(),
-        //                 password: params.get("smtp_password").unwrap().clone(),
-        //                 encryption: params.get("smtp_encryption").map(|v| v.clone()),
-        //                 auth: params.get("smtp_auth").map(|v| v.parse::<bool>().unwrap()),
-        //                 debug: params.get("smtp_debug").map(|v| v.parse::<bool>().unwrap()),
-        //                 timeout: params
-        //                     .get("smtp_timeout")
-        //                     .map(|v| v.parse::<u32>().unwrap()),
-        //                 tls_verify: params
-        //                     .get("smtp_tls_verify")
-        //                     .map(|v| v.parse::<bool>().unwrap()),
-        //                 tls_ca_certs: params.get("smtp_tls_ca_certs").map(|v| v.clone()),
-        //                 tls_key: params.get("smtp_tls_key").map(|v| v.clone()),
-        //                 tls_cert: params.get("smtp_tls_cert").map(|v| v.clone()),
-        //                 tls_ciphers: params.get("smtp_tls_ciphers").map(|v| v.clone()),
-        //             },
-        //         }),
-        //         "sms-twilio" => NotificationConfigType::TwilioSms(TwilioSmsConfig {
-        //             account_sid: params.get("account_sid").unwrap().clone(),
-        //             auth_token: params.get("auth_token").unwrap().clone(),
-        //             from: params.get("from").unwrap().clone(),
-        //             to: params.get("to").unwrap().clone(),
-        //             body: params.get("body").unwrap().clone(),
-        //             media_urls: params
-        //                 .get("media_urls")
-        //                 .map(|v| v.split(',').map(|s| s.trim().to_string()).collect()),
-        //             mms: params.get("mms").map(|v| v.parse::<bool>().unwrap()),
-        //             sender_id: params.get("sender_id").map(|v| v.clone()),
-        //             carrier: params.get("carrier").map(|v| v.clone()),
-        //             carrier_lookup: params
-        //                 .get("carrier_lookup")
-        //                 .map(|v| v.parse::<bool>().unwrap()),
-        //             carrier_lookup_country_code: params
-        //                 .get("carrier_lookup_country_code")
-        //                 .map(|v| v.clone()),
-        //         }),
-        //         "phone-call" => NotificationConfigType::PhoneCall(PhoneCallConfig {
-        //             account_sid: params.get("account_sid").unwrap().clone(),
-        //             auth_token: params.get("auth_token").unwrap().clone(),
-        //             from: params.get("from").unwrap().clone(),
-        //             to: params.get("to").unwrap().clone(),
-        //             url: params.get("url").unwrap().clone(),
-        //             method: params.get("method").map(|v| v.clone()),
-        //             timeout: params.get("timeout").map(|v| v.parse::<u32>().unwrap()),
-        //             record: params.get("record").map(|v| v.parse::<bool>().unwrap()),
-        //             status_callback: params.get("status_callback").map(|v| v.clone()),
-        //             status_callback_method: params.get("status_callback_method").map(|v| v.clone()),
-        //             machine_detection: params
-        //                 .get("machine_detection")
-        //                 .map(|v| v.parse::<bool>().unwrap()),
-        //             machine_detection_timeout: params
-        //                 .get("machine_detection_timeout")
-        //                 .map(|v| v.parse::<u32>().unwrap()),
-        //             machine_detection_url: params.get("machine_detection_url").map(|v| v.clone()),
-        //             machine_detection_method: params
-        //                 .get("machine_detection_method")
-        //                 .map(|v| v.clone()),
-        //         }),
-        //         "cmd" => NotificationConfigType::Command(CommandConfig {
-        //             command: params.get("command").unwrap().clone(),
-        //             args: params.get("args").map(|v| v.clone()),
-        //             timeout: params.get("timeout").map(|v| v.parse::<u32>().unwrap()),
-        //             retry: params.get("retry").map(|v| v.parse::<u32>().unwrap()),
-        //             retry_delay: params.get("retry_delay").map(|v| v.parse::<u32>().unwrap()),
-        //         }),
-        //         "http" => NotificationConfigType::Http(HttpConfig {
-        //             url: params.get("url").unwrap().clone(),
-        //             method: params.get("method").unwrap().clone(),
-        //             headers: params.get("headers").map(|v| {
-        //                 v.split(',')
-        //                     .map(|s| HttpHeader {
-        //                         key: s.split('=').next().unwrap().trim().to_string(),
-        //                         value: s.split('=').last().unwrap().trim().to_string(),
-        //                     })
-        //                     .collect()
-        //             }),
-        //             body: params.get("body").map(|v| v.clone()),
-        //             timeout: params.get("timeout").map(|v| v.parse::<u32>().unwrap()),
-        //             retry: params.get("retry").map(|v| v.parse::<u32>().unwrap()),
-        //             retry_delay: params.get("retry_delay").map(|v| v.parse::<u32>().unwrap()),
-        //         }),
-        //         _ => unreachable!(),
-        //     },
-        // });
-    }
-
-    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
-        write_config(self)
     }
 }
 
@@ -402,12 +280,4 @@ pub fn get_config_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(CONFIG_DIR)
-}
-
-pub fn read_config(name: &str) -> Result<ConfigSet, Box<dyn std::error::Error>> {
-    ConfigManager::new().read_config(name)
-}
-
-pub fn write_config(config_set: &ConfigSet) -> Result<(), Box<dyn std::error::Error>> {
-    ConfigManager::new().write_config(config_set)
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -8,7 +8,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Line, Span, Text},
+    text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
     Frame, Terminal,
 };
@@ -430,18 +430,6 @@ impl Editor {
         );
 
         f.render_widget(list, area);
-    }
-
-    fn render_add_config_hints(&self, f: &mut Frame, area: Rect) {
-        let hints = match self.mode {
-            EditorMode::Normal => "↑↓: Navigate | Enter: Select | q: Quit",
-            EditorMode::AddingConfig => "↑↓: Navigate | Enter: Add | Esc: Cancel",
-            EditorMode::Editing => "Enter: Save | Esc: Cancel",
-            EditorMode::Notification => "↑↓: Navigate | Enter: Edit Field | Esc: Back | q: Quit",
-        };
-
-        let hints = Paragraph::new(hints).block(Block::default().borders(Borders::ALL));
-        f.render_widget(hints, area);
     }
 
     fn get_notification_field_count(&self) -> usize {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,16 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum NotificationError {
+    #[allow(dead_code)]
     #[error("Configuration error: {0}")]
     ConfigError(String),
+    #[allow(dead_code)]
     #[error("Execution error: {0}")]
     ExecutionError(String),
+    #[allow(dead_code)]
     #[error("Notification error: {0}")]
     NotificationError(String),
+    #[allow(dead_code)]
     #[error("Unknown error: {0}")]
     Unknown(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,5 +79,19 @@ fn main() {
         Commands::Test { name: _ } => {
             // TODO: Implement test logic
         }
+
+        Commands::Send {
+            headline,
+            config_set,
+        } => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            if let Err(e) = rt.block_on(app::send_notification(
+                &config_set,
+                &headline,
+            )) {
+                error!("Error sending notification: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
 }

--- a/src/notifications/email.rs
+++ b/src/notifications/email.rs
@@ -1,4 +1,4 @@
-use super::NotificationSender;
+use super::{NotificationSender, NotificationOptions};
 use std::error::Error;
 
 pub struct EmailNotifier {
@@ -7,8 +7,16 @@ pub struct EmailNotifier {
 
 #[async_trait::async_trait]
 impl NotificationSender for EmailNotifier {
-    async fn send(&self, message: &str) -> Result<(), Box<dyn Error>> {
+    async fn send(&self, _message: &str) -> Result<(), Box<dyn Error>> {
         // TODO: Implement email sending using lettre
         Ok(())
+    }
+
+    async fn send_with_options(
+        &self,
+        message: &str,
+        _options: &NotificationOptions,
+    ) -> Result<(), Box<dyn Error>> {
+        self.send(message).await
     }
 }

--- a/src/notifications/lark.rs
+++ b/src/notifications/lark.rs
@@ -1,7 +1,7 @@
-use crate::notifications::NotificationSender;
+use crate::notifications::{NotificationOptions, NotificationSender};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use hmac::{Hmac, Mac};
-use log::{debug, error, info};
+use log::{error, info};
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::json;
@@ -28,18 +28,19 @@ impl LarkNotifier {
 
     fn generate_sign(&self, timestamp: u64) -> String {
         let string_to_sign = format!("{}\n{}", timestamp, self.sign_key);
-        let mut mac = Hmac::<Sha256>::new_from_slice(string_to_sign.as_bytes())
+        let mac = Hmac::<Sha256>::new_from_slice(string_to_sign.as_bytes())
             .expect("HMAC can take key of any size");
         let result = mac.finalize();
         STANDARD.encode(result.into_bytes())
     }
 
-    fn format_message(&self, message: &str) -> String {
-        if let Some(user_id) = &self.at_user_id {
-            format!("<at user_id=\"{}\"></at>\n{}", user_id, message)
-        } else {
-            message.to_string()
+    fn format_message(&self, message: &str, mention_user: bool) -> String {
+        if mention_user {
+            if let Some(user_id) = &self.at_user_id {
+                return format!("<at user_id=\"{}\"></at>\n{}", user_id, message);
+            }
         }
+        message.to_string()
     }
 }
 
@@ -51,11 +52,15 @@ struct LarkResponse {
 
 #[async_trait::async_trait]
 impl NotificationSender for LarkNotifier {
-    async fn send(&self, message: &str) -> Result<(), Box<dyn Error>> {
+    async fn send_with_options(
+        &self,
+        message: &str,
+        options: &NotificationOptions,
+    ) -> Result<(), Box<dyn Error>> {
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
         let sign = self.generate_sign(timestamp);
-        let formatted_message = self.format_message(message);
+        let formatted_message = self.format_message(message, options.mention_user);
 
         let body = json!({
             "timestamp": timestamp,

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -1,8 +1,6 @@
 use crate::config::{
-    CommandConfig, EmailConfig, HttpConfig, NotificationConfigType, PhoneCallConfig,
-    TelegramConfig, TwilioSmsConfig,
+    NotificationConfigType, TelegramConfig,
 };
-use std::collections::HashMap;
 
 pub mod email;
 pub mod http_request;
@@ -11,17 +9,27 @@ pub mod phone_call_twilio;
 pub mod sms_twilio;
 pub mod telegram;
 
+#[derive(Debug, Default, Clone)]
+pub struct NotificationOptions {
+    pub silent: bool,
+    pub mention_user: bool,
+}
+
 #[async_trait::async_trait]
 pub trait NotificationSender: Send + Sync {
-    async fn send(&self, message: &str) -> Result<(), Box<dyn std::error::Error>>;
+    async fn send(&self, message: &str) -> Result<(), Box<dyn std::error::Error>> {
+        self.send_with_options(message, &NotificationOptions::default()).await
+    }
+    
+    async fn send_with_options(&self, message: &str, options: &NotificationOptions) -> Result<(), Box<dyn std::error::Error>>;
 }
 
 pub fn create_notification_sender(
     config: &NotificationConfigType,
 ) -> Result<Box<dyn NotificationSender>, Box<dyn std::error::Error>> {
     match config {
-        NotificationConfigType::Telegram(TelegramConfig { token, chat_id, .. }) => Ok(Box::new(
-            telegram::TelegramNotifier::new(token.clone(), chat_id.clone()),
+        NotificationConfigType::Telegram(TelegramConfig { token, chat_id, at }) => Ok(Box::new(
+            telegram::TelegramNotifier::new(token.clone(), chat_id.clone(), at.clone()),
         )),
         NotificationConfigType::Email(_) => Err("Email notification not implemented yet".into()),
         NotificationConfigType::Http(_) => Err("HTTP notification not implemented yet".into()),

--- a/src/notifications/telegram.rs
+++ b/src/notifications/telegram.rs
@@ -1,50 +1,66 @@
-use crate::notifications::NotificationSender;
+use crate::notifications::{NotificationOptions, NotificationSender};
 use reqwest::Client;
-use serde_json::json;
-use std::collections::HashMap;
+use serde_json::{json, Value};
 use std::error::Error;
+
+fn build_client() -> Client {
+    std::panic::catch_unwind(|| Client::new()).unwrap_or_else(|_| {
+        Client::builder()
+            .no_proxy()
+            .build()
+            .expect("Failed to build reqwest client")
+    })
+}
 
 pub struct TelegramNotifier {
     bot_token: String,
     chat_id: String,
+    at: Option<String>,
     client: Client,
 }
 
 impl TelegramNotifier {
-    pub fn new(bot_token: String, chat_id: String) -> Self {
+    pub fn new(bot_token: String, chat_id: String, at: Option<String>) -> Self {
         Self {
             bot_token,
             chat_id,
-            client: Client::new(),
+            at,
+            client: build_client(),
         }
     }
 
-    pub fn create(
-        params: HashMap<String, String>,
-    ) -> Result<Box<dyn NotificationSender>, Box<dyn Error>> {
-        let bot_token = params
-            .get("bot_token")
-            .ok_or("Telegram bot token not configured")?
-            .clone();
+    fn format_message(&self, message: &str, mention_user: bool) -> String {
+        if !mention_user {
+            return message.to_string();
+        }
 
-        let chat_id = params
-            .get("chat_id")
-            .ok_or("Telegram chat ID not configured")?
-            .clone();
+        let Some(at) = self.at.as_ref() else {
+            return message.to_string();
+        };
+        let at = at.trim();
+        if at.is_empty() {
+            return message.to_string();
+        }
 
-        Ok(Box::new(TelegramNotifier::new(bot_token, chat_id)))
+        format!("{} {}", at, message)
     }
-}
 
-#[async_trait::async_trait]
-impl NotificationSender for TelegramNotifier {
-    async fn send(&self, message: &str) -> Result<(), Box<dyn Error>> {
+    async fn send_inner(
+        &self,
+        message: &str,
+        options: &NotificationOptions,
+    ) -> Result<(), Box<dyn Error>> {
         let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
+        let text = self.format_message(message, options.mention_user);
 
-        let body = json!({
+        let mut body = json!({
             "chat_id": self.chat_id,
-            "text": message,
+            "text": text,
         });
+
+        if options.silent {
+            body["disable_notification"] = Value::Bool(true);
+        }
 
         let response = self.client.post(&url).json(&body).send().await?;
 
@@ -59,6 +75,22 @@ impl NotificationSender for TelegramNotifier {
             )
             .into())
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl NotificationSender for TelegramNotifier {
+    async fn send(&self, message: &str) -> Result<(), Box<dyn Error>> {
+        self.send_with_options(message, &NotificationOptions::default())
+            .await
+    }
+
+    async fn send_with_options(
+        &self,
+        message: &str,
+        options: &NotificationOptions,
+    ) -> Result<(), Box<dyn Error>> {
+        self.send_inner(message, options).await
     }
 }
 
@@ -126,6 +158,7 @@ mod tests {
         let notifier = TelegramNotifier::new(
             TEST_CREDENTIALS.bot_token.clone(),
             TEST_CREDENTIALS.chat_id.clone(),
+            None,
         );
 
         runtime.block_on(async {

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,15 +1,6 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::*;
+use notifyme::config::ConfigManager;
 
-    #[test]
-    fn test_read_config() {
-        // TODO: Implement test cases for reading configs
-    }
-
-    #[test]
-    fn test_write_config() {
-        // TODO: Implement test cases for writing configs
-    }
+#[test]
+fn test_config_manager_constructs() {
+    let _ = ConfigManager::new();
 }


### PR DESCRIPTION
- Remove MCP server implementation and related documentation.
- Add notifyme send command for direct high-impact notifications.
- Refactor NotificationSender trait to support send_with_options (silence and user mentions).
- Implement high-impact notification logic in App.
- Clean up unused code, imports, and fix compiler warnings across the project.
- Add SKILL.md and update README.md with Agent integration guides.